### PR TITLE
ignore invalid host header error

### DIFF
--- a/messWebsite/settings.py
+++ b/messWebsite/settings.py
@@ -242,6 +242,9 @@ EMAIL_HOST_PASSWORD = env("EMAIL_HOST_PASSWORD")
 if not DEBUG:
     import sentry_sdk
     from sentry_sdk.integrations.django import DjangoIntegration
+    from sentry_sdk.integrations.logging import ignore_logger
+
+    ignore_logger("django.security.DisallowedHost")
 
     sentry_sdk.init(
         dsn=env("SENTRY_DSN"),


### PR DESCRIPTION
A lot of errors are coming around it due to automated scripts that check for vulnerabilities. Ref: https://github.com/cookiecutter/cookiecutter-django/issues/914#issuecomment-263614761

Implemented a workaround to silence them as Django handles them. Ref: https://github.com/getsentry/sentry-python/issues/641#issuecomment-595391423